### PR TITLE
Update JsonApiUrlBuilder.java

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/core/internal/utils/JsonApiUrlBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/core/internal/utils/JsonApiUrlBuilder.java
@@ -5,6 +5,7 @@ import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.TreeMap;
 
 import io.katharsis.core.internal.query.QuerySpecAdapter;
 import io.katharsis.legacy.internal.QueryParamsAdapter;
@@ -81,8 +82,9 @@ public class JsonApiUrlBuilder {
 
 		UrlParameterBuilder urlBuilder = new UrlParameterBuilder(url);
 		if (query instanceof QuerySpec) {
-			QuerySpec querySpec = (QuerySpec) query;
-			urlBuilder.addQueryParameters(querySpecSerializer.serialize(querySpec));
+			QuerySpec querySpec = (QuerySpec) query;			
+			urlBuilder.addQueryParameters(new TreeMap<>(querySpecSerializer.serialize(querySpec)));
+
 		}
 		else if (query instanceof QueryParams) {
 			QueryParams queryParams = (QueryParams) query;

--- a/katharsis-core/src/main/java/io/katharsis/core/internal/utils/JsonApiUrlBuilder.java
+++ b/katharsis-core/src/main/java/io/katharsis/core/internal/utils/JsonApiUrlBuilder.java
@@ -84,7 +84,6 @@ public class JsonApiUrlBuilder {
 		if (query instanceof QuerySpec) {
 			QuerySpec querySpec = (QuerySpec) query;			
 			urlBuilder.addQueryParameters(new TreeMap<>(querySpecSerializer.serialize(querySpec)));
-
 		}
 		else if (query instanceof QueryParams) {
 			QueryParams queryParams = (QueryParams) query;


### PR DESCRIPTION
PR Overview:
_________________________________________________________________________________________________________
This PR fixes the flaky/non-deterministic behavior of the following test because it assumes the ordering.

[io.katharsis.resource.paging.PagedLinksInformationQuerySpecTest#testPagingLast](https://github.com/katharsis-project/katharsis-framework/blob/73d1a8763c49c5cf4643d43e2dbfedb647630c46/katharsis-core/src/test/java/io/katharsis/resource/paging/PagedLinksInformationQuerySpecTest.java#L86C1-L86C1)

[io.katharsis.resource.paging.PagedLinksInformationQuerySpecTest#testPagingFirst](https://github.com/katharsis-project/katharsis-framework/blob/73d1a8763c49c5cf4643d43e2dbfedb647630c46/katharsis-core/src/test/java/io/katharsis/resource/paging/PagedLinksInformationQuerySpecTest.java#L73)

[io.katharsis.resource.paging.PagedLinksInformationQuerySpecTest#testPaging](https://github.com/katharsis-project/katharsis-framework/blob/73d1a8763c49c5cf4643d43e2dbfedb647630c46/katharsis-core/src/test/java/io/katharsis/resource/paging/PagedLinksInformationQuerySpecTest.java#L45)

[io.katharsis.queryspec.DefaultQuerySpecSerializerTest#testPagingOnRelation](https://github.com/katharsis-project/katharsis-framework/blob/73d1a8763c49c5cf4643d43e2dbfedb647630c46/katharsis-core/src/test/java/io/katharsis/queryspec/DefaultQuerySpecSerializerTest.java#L140)

[io.katharsis.queryspec.DefaultQuerySpecSerializerTest#testPaging](https://github.com/katharsis-project/katharsis-framework/blob/73d1a8763c49c5cf4643d43e2dbfedb647630c46/katharsis-core/src/test/java/io/katharsis/queryspec/DefaultQuerySpecSerializerTest.java#L132C1-L132C1)

Test Overview:
_________________________________________________________________________________________________________
In all of the above tests, a [urlBuilder](https://github.com/njain2208/katharsis-framework/blob/795f84873a75dd7de0781826bdff9cad08a1b2eb/katharsis-core/src/main/java/io/katharsis/core/internal/utils/JsonApiUrlBuilder.java#L83) is employed to construct URLs by incorporating various query parameters. However, due to the storage of parameters in a non-deterministic map, the order in which keys and values are stored becomes unpredictable. This lack of predictability is evident in the test failure below, where the urlBuilder exhibits a different order for the 'offset' and 'limit' parameters in the URL compared to the expected order.

This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC.

```
[ERROR]   DefaultQuerySpecSerializerTest.testPaging:136->check:167 expected:<...7.0.0.1/tasks/?page[[limit]=2&page[offset]=1]> but was:<...7.0.0.1/tasks/?page[[offset]=1&page[limit]=2]>
[ERROR]   DefaultQuerySpecSerializerTest.testPagingOnRelation:147 expected:<...hips/projects/?page[[limit]=2&page[offset]=1]> but was:<...hips/projects/?page[[offset]=1&page[limit]=2]>
[ERROR]   PagedLinksInformationQuerySpecTest.testPaging:52 expected:<...7.0.0.1/tasks/?page[[limit]=2&page[offset]=4]> but was:<...7.0.0.1/tasks/?page[[offset]=4&page[limit]=2]>
[ERROR]   PagedLinksInformationQuerySpecTest.testPagingFirst:80 expected:<...7.0.0.1/tasks/?page[[limit]=3&page[offse]t]=3> but was:<...7.0.0.1/tasks/?page[[offset]=3&page[limi]t]=3>
[ERROR]   PagedLinksInformationQuerySpecTest.testPagingLast:93 expected:<...7.0.0.1/tasks/?page[[limit]=4&page[offse]t]=4> but was:<...7.0.0.1/tasks/?page[[offset]=4&page[limi]t]=4>

```

You can reproduce the issue by running the following commands (the below command is for PagedLinksInformationQuerySpecTest, please change the tests to target other tests) -

mvn install -pl katharsis-core -am -DskipTests
mvn test -pl katharsis-core  -Dtest=-Dtest=io.katharsis.resource.paging.PagedLinksInformationQuerySpecTest
mvn -pl katharsis-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=io.katharsis.resource.paging.PagedLinksInformationQuerySpecTest

Fix:
_________________________________________________________________________________________________________
To fix the issue I decided to store all of the query parameters in the urlBuilder in a TreeMap which is deterministic in nature.

https://github.com/njain2208/katharsis-framework/blob/795f84873a75dd7de0781826bdff9cad08a1b2eb/katharsis-core/src/main/java/io/katharsis/core/internal/utils/JsonApiUrlBuilder.java#L86