### PR TITLE
Update QuerySpec.java

### DIFF
--- a/katharsis-core/src/main/java/io/katharsis/queryspec/QuerySpec.java
+++ b/katharsis-core/src/main/java/io/katharsis/queryspec/QuerySpec.java
@@ -1,10 +1,6 @@
 package io.katharsis.queryspec;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import io.katharsis.core.internal.utils.CompareUtils;
@@ -162,7 +158,11 @@ public class QuerySpec {
 	}
 
 	public void addFilter(FilterSpec filterSpec) {
-		this.filters.add(filterSpec);
+		int index = Collections.binarySearch(this.filters, filterSpec,Comparator.comparing(FilterSpec::toString));
+		if (index < 0) {
+			index = -index - 1;
+		}
+		this.filters.add(index, filterSpec);
 	}
 
 	public void addSort(SortSpec sortSpec) {
@@ -174,7 +174,11 @@ public class QuerySpec {
 	}
 
 	public void includeRelation(List<String> attrPath) {
-		this.includedRelations.add(new IncludeRelationSpec(attrPath));
+		int index = Collections.binarySearch(includedRelations, new IncludeRelationSpec(attrPath),Comparator.comparing(IncludeRelationSpec::toString));
+		if (index < 0) {
+			index = -index - 1;
+		}
+		includedRelations.add(index, new IncludeRelationSpec(attrPath));
 	}
 
 	/**


### PR DESCRIPTION
PR Overview:
_________________________________________________________________________________________________________
This PR fixes the flaky/non-deterministic behavior of the following test because it assumes the ordering.

[io.katharsis.legacy.queryParams.DefaultQueryParamsConverterTest#testIncludeRelationsMultipleSame](https://github.com/katharsis-project/katharsis-framework/blob/73d1a8763c49c5cf4643d43e2dbfedb647630c46/katharsis-core/src/test/java/io/katharsis/legacy/queryParams/DefaultQueryParamsConverterTest.java#L358)

[io.katharsis.legacy.queryParams.DefaultQueryParamsConverterTest#testFilterMultipleDifferent](https://github.com/katharsis-project/katharsis-framework/blob/73d1a8763c49c5cf4643d43e2dbfedb647630c46/katharsis-core/src/test/java/io/katharsis/legacy/queryParams/DefaultQueryParamsConverterTest.java#L134)

Test Overview:
_________________________________________________________________________________________________________
In all of the above tests, a [urlBuilder](https://github.com/njain2208/katharsis-framework/blob/795f84873a75dd7de0781826bdff9cad08a1b2eb/katharsis-core/src/main/java/io/katharsis/core/internal/utils/JsonApiUrlBuilder.java#L83) is employed to construct URLs by incorporating various query parameters. However, due to the storage of parameters in a non-deterministic map, the order in which keys and values are stored becomes unpredictable. This lack of predictability is evident in the test failure below, where the urlBuilder exhibits a different order for the 'offset' and 'limit' parameters in the URL compared to the expected order.

This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC.

```
[ERROR]   DefaultQueryParamsConverterTest.testFilterMultipleDifferent:144->transitivityCheckTask:442 transitivity check expected:<QuerySpec{resourceClass=class io.katharsis.resource.mock.models.Task, limit=null, offset=0, filters=[name EQ [bar, foo], id EQ [20, 12]], sort=[], includedFields=[], includedRelations=[], relatedSpecs={}}> but was:<QuerySpec{resourceClass=class io.katharsis.resource.mock.models.Task, limit=null, offset=0, filters=[id EQ [12, 20], name EQ [foo, bar]], sort=[], includedFields=[], includedRelations=[], relatedSpecs={}}>
[ERROR]   DefaultQueryParamsConverterTest.testIncludeRelationsMultipleSame:367->transitivityCheckTask:442 transitivity check expected:<QuerySpec{resourceClass=class io.katharsis.resource.mock.models.Task, limit=null, offset=0, filters=[], sort=[], includedFields=[], includedRelations=[project, projects], relatedSpecs={}}> but was:<QuerySpec{resourceClass=class io.katharsis.resource.mock.models.Task, limit=null, offset=0, filters=[], sort=[], includedFields=[], includedRelations=[projects, project], relatedSpecs={}}>
```

You can reproduce the issue by running the following commands (the below command is for PagedLinksInformationQuerySpecTest, please change the tests to target other tests) -

```
mvn install -pl katharsis-core -am -DskipTests
mvn test -pl katharsis-core  -Dtest=-Dtest=io.katharsis.resource.paging.PagedLinksInformationQuerySpecTest
mvn -pl katharsis-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=io.katharsis.legacy.queryParams.DefaultQueryParamsConverterTest#testFilterMultipleDifferent
```

Fix:
_________________________________________________________________________________________________________
To fix the issue I added elements in includedRelations, and filters in the List in an alphabetic order.

https://github.com/njain2208/katharsis-framework/blob/0f76786b5fb44f803c741044152ac0b98f8a71b4/katharsis-core/src/main/java/io/katharsis/queryspec/QuerySpec.java#L176-L183

https://github.com/njain2208/katharsis-framework/blob/0f76786b5fb44f803c741044152ac0b98f8a71b4/katharsis-core/src/main/java/io/katharsis/queryspec/QuerySpec.java#L162-L171